### PR TITLE
No dead enemies

### DIFF
--- a/src/main/java/communicationmod/CommandExecutor.java
+++ b/src/main/java/communicationmod/CommandExecutor.java
@@ -241,11 +241,18 @@ public class CommandExecutor {
             }
         }
         AbstractMonster target_monster = null;
+        ArrayList<AbstractMonster> liveMonsters = new ArrayList();
+        for (AbstractMonster m : AbstractDungeon.getCurrRoom().monsters.monsters) {
+            if (!m.isDeadOrEscaped()) {
+                liveMonsters.add(m);
+            }
+        }
+
         if (monster_index != -1) {
-            if (monster_index < 0 || monster_index >= AbstractDungeon.getCurrRoom().monsters.monsters.size()) {
+            if (monster_index < 0 || monster_index >= liveMonsters.size()) {
                 throw new InvalidCommandException(tokens, InvalidCommandException.InvalidCommandFormat.OUT_OF_BOUNDS, Integer.toString(monster_index));
             } else {
-                target_monster = AbstractDungeon.getCurrRoom().monsters.monsters.get(monster_index);
+                target_monster = liveMonsters.get(monster_index);
             }
         }
         if((card_index < 1) || (card_index > AbstractDungeon.player.hand.size()) || !(AbstractDungeon.player.hand.group.get(card_index - 1).canUse(AbstractDungeon.player, target_monster))) {

--- a/src/main/java/communicationmod/GameStateConverter.java
+++ b/src/main/java/communicationmod/GameStateConverter.java
@@ -515,7 +515,9 @@ public class GameStateConverter {
         HashMap<String, Object> state = new HashMap<>();
         ArrayList<Object> monsters = new ArrayList<>();
         for(AbstractMonster monster : AbstractDungeon.getCurrRoom().monsters.monsters) {
-            monsters.add(convertMonsterToJson(monster));
+            if (!monster.isDeadOrEscaped()) {
+                monsters.add(convertMonsterToJson(monster));
+            }
         }
         state.put("monsters", monsters);
         ArrayList<Object> draw_pile = new ArrayList<>();
@@ -668,8 +670,6 @@ public class GameStateConverter {
      * "move_hits" (int): The number of hits done by the current attack
      * "last_move_id" (int): The move id byte for the monster's previous move
      * "second_last_move_id" (int): The move id byte from 2 moves ago
-     * "half_dead" (boolean): Whether the monster is half dead
-     * "is_gone" (boolean): Whether the monster is dead or has run away
      * "powers" (list): The monster's current powers
      * Note: If the player has Runic Dome, intent will always return NONE
      * @param monster The monster to convert
@@ -709,8 +709,6 @@ public class GameStateConverter {
         if(monster.moveHistory.size() >= 3) {
             jsonMonster.put("second_last_move_id", monster.moveHistory.get(monster.moveHistory.size() - 3));
         }
-        jsonMonster.put("half_dead", monster.halfDead);
-        jsonMonster.put("is_gone", monster.isDeadOrEscaped());
         jsonMonster.put("block", monster.currentBlock);
         jsonMonster.put("powers", convertCreaturePowersToJson(monster));
         return jsonMonster;


### PR DESCRIPTION
Exclude dead or escaped enemies from the game state response. This ensures that the monster array has a bound length. 